### PR TITLE
Update Qvc_Log.qvs

### DIFF
--- a/QVC_Source/Qvc_Log.qvs
+++ b/QVC_Source/Qvc_Log.qvs
@@ -61,7 +61,7 @@ IF $(Qvc.Log.v.KeepDays) > 0 THEN		// If requested to keep previous logs...
 			@1 as [$(_levelField)], 
     	 	@2 as [$(Qvc.Log.v.LogField)]
 		FROM "$(Qvc.Log.v.LogFileName)"
-		(txt, no labels, delimiter is ',', msq, header is 1 lines)
+		(CodePage is 65001, txt, no labels, delimiter is ',', msq, header is 1 lines)
 		WHERE today(1) - Date#(subfield(@2,' ',2)) < $(Qvc.Log.v.KeepDays)
 		; 
 		// Get max value of current counter


### PR DESCRIPTION
Added "CodePage is 65001" for LOAD stored log file.

Store as txt (UTF-8) and LOAD (?) use different encoding. Results in german umlaute (ÜüöÖäÄ) getting screwed after loading logs from file