### PR TITLE
Update Qvc_Calendar.qvs

### DIFF
--- a/QVC_Source/Qvc_Calendar.qvs
+++ b/QVC_Source/Qvc_Calendar.qvs
@@ -102,6 +102,8 @@ SET _fDay='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.Day)]';
 SET _fWeekday='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.Weekday)]';
 SET _fYear='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.Year)]';
 SET _fMonth='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.Month)]';
+// Mark Miller (RHS) 8/9/2016 - Add Month full name to the calendar
+SET _fMonthName='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.Month)Name]';
 SET _fYearMonth='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.YearMonth)]';
 SET _fQuarter='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.Quarter)]';
 SET _f_MonthSerial='[$(_fieldPrefix)_MonthSerial]';
@@ -133,7 +135,12 @@ LOAD
     Day(Date)						as $(_fDay),
     Weekday(Date)					as $(_fWeekday),
     Year(AddMonths(Date,$(_monthOffset))) 	as $(_fYear),
-    Month(Date)						as $(_fMonth),
+// Mark Miller (RHS) 2/15/2016 - Express the month as a Dual so the months can be sorted by number so the starting month of the year
+// can be always first in list boxes (especially useful for fiscal calendars)
+	Dual(Month(Date), Num(Month(AddMonths(Date,$(_monthOffset))))) AS $(_fMonth),
+//    Month(Date)						as $(_fMonth),
+// Mark Miller (RHS) 8/9/2016 - Add Month full name to the calendar
+	Dual(Date([Date],'MMMM'), Num(Month(AddMonths(Date,$(_monthOffset))))) as $(_fMonthName),
     'Q' & Ceil(Month(AddMonths(Date,$(_monthOffset))) / 3)		as $(_fQuarter),
     num(Date)					 	as $(_f_DateSerial),
     AutoNumber(MonthStart(Date),'$(_f_MonthSerial)') 	as $(_f_MonthSerial),
@@ -150,6 +157,235 @@ SET _concatenate=;
 SET _qvctemp.v.IncludeExtension=;
 ///$tab Calendar Set Variables
 IF $(Qvc.Calendar.v.CreateSetVariables) THEN	// If SA variables requested,
+	// Mark Miller (RHS) 8/10/2016 - Break SetVariable generation out to separate routine.
+	CALL Qvc.GenerateCalendarSetVariables;
+ENDIF
+
+///$tab Cleanup
+// Cleanup temp variables
+SET _fDate=;
+SET _fDay=;
+SET _fWeekday=;
+SET _fYear=;
+SET _fMonth=;
+// Mark Miller (RHS) 8/9/2016 - Add Month full name to the calendar
+SET _fMonthName=;
+SET _fYearMonth=;
+SET _fQuarter=;
+SET _f_MonthSerial=;
+SET _f_QuarterSerial=;
+SET _f_WeekSerial=;
+SET _f_DateSerial=;
+SET _monthOffset =;
+			
+END SUB	
+// End of Qvc.Calendar Sub
+
+///$tab CalendarFromField
+SUB Qvc.CalendarFromField(_fieldname, _tableName, _fieldPrefix, _firstMonth)
+/**
+@source Qvc_Calendar.qvs
+Create a Master Calendar based on the Min and Max values of an existing field. The fieldname is used as the "Date" field in the calendar, providinging automatic lkinkage.
+
+This Sub calls Qvc.Calendar to generate the calendar. See the doc for Qvc.Calendar to understand the output and available configuration variables. 
+
+@syntax CALL Qvc.CalendarFromField ('Fieldname', ['CalendarTableName'], ['FieldPrefix'], [FirstMonth]); 
+ 
+@param 1 String. Fieldname that will be used to establish Min and Max values for the Calendar Date.
+@param 2 String. Optional - the name of the Calendar table. If not supplied the default is "MasterCalendar"
+@param 3 String. Optional - A prefix that will be prepended to all field names and Set variables created for this calendar. For the set vars, blanks in this string will be replaced with underscores.
+@param 4 Number. Optional - First month of the year. If you want to work with a fiscal year starting in April, specify 4. 
+
+*/
+UNQUALIFY "_qvctemp.*";	// UNQUALIFY all qvctemp fields
+
+CALL Qvc.GetFieldValues('_vStats', '$(_fieldname)');
+
+//SET _SaveCalendarDateField='$(Qvc.Calendar.v.Field.Date)';	// Save off the current Date fieldname.
+//SET Qvc.Calendar.v.Field.Date='$(_fieldname)';		// Use the parameter fieldname for the Date field.
+SET _Qvc.Calendar.v.Field.Date.Override='$(_fieldname)';		// Use the parameter fieldname for the Date field.
+// Call Qvc.Calendar to do the work.
+CALL Qvc.Calendar(_vStats.Min, _vStats.Max, '$(_tableName)', '$(_fieldPrefix)', '$(_firstMonth)');
+//SET Qvc.Calendar.v.Field.Date='$(_SaveCalendarDateField)';		// Restore the saved value
+
+SET _Qvc.Calendar.v.Field.Date.Override=;	// Reset to default behavior
+//SET _SaveCalendarDateField=;
+SET _vStats.Min=;
+SET _vStats.Max=;
+END SUB	
+// End of Qvc.CalendarFromField Sub
+
+// Mark Miller (RHS) 8/8/2016 - Add new routine to generate calendar without filling in missing dates.
+SUB Qvc.CalendarNoFill(_fieldname, _fieldTableName, _tableName, _fieldPrefix, _firstMonth)
+/**
+@source Qvc_Calendar.qvs
+Create a Master Calendar Table.
+
+NOTE! This routine varies from Qvc.Calendar in that only valid dates are generated - dates missing from the data field are not "filled in".
+
+By default, this routine creates "vSetxxx" and "vSetxxxModifier" variables containing time period set analysis expressions. Creation of the variables can be suppressed via a configuration variable. Note also that the variable names may be prefixed with the string given in parameter 4.
+
+--Code Extension-- ExtFields
+Default file: CalendarExtFields.qvs
+Specified by variable: Qvc.Calendar.v.ExtFields 
+
+The contents of the extension file are Included in the Calendar LOAD statement to create additional fields in the generated Calendar. 
+
+The script may be any field definition allowable in a LOAD statement. The current date being processed must be referenced as field "Date". The AS clause naming the new field must be written  "as [$(_fieldPrefix)newfield]".
+
+For example, to add two new fields for Week and Year-Week:
+
+,week(Date) as [$(_fieldPrefix)Week]
+,Year(Date) & '-' & week(Date) as [$(_fieldPrefix)Year-Week]
+
+
+--Code Extension-- ExtSetVariables
+Default file: CalendarExtSetVariables.qvs
+Specified by variable: Qvc.Calendar.v.ExtSetVariables
+
+The contents of the extension file are Included in the section that creates SetXXX period analysis variables. You may add any complete script statements. Usually this would be SET statements to create additional variables.  
+
+@syntax CALL Qvc.CalendarNoFill (FieldName, FieldTableName, ['CalendarTableName'], ['FieldPrefix'], [FirstMonth]);  
+
+@param 1 String. The field name the calendar is generated from.
+@param 2 String. The table name the field exists in that the calendar is generated from. Must be a resident table.
+@param 3 String. Optional - the name of the Calendar table. If not supplied the default is "MasterCalendar"
+@param 4 String. Optional - A prefix that will be prepended to all field names and Set variables created for this calendar. For the set vars, blanks in this string will be replaced with underscores.
+@param 5 Number. Optional - First month of the year. If you want to work with a fiscal year starting in April, specify 4. If you want your fiscal year to use the higher year values, use a negative value like -8.
+
+@var Qvc.Calendar.v.CreateSetVariables in -1/0 (true/false) Should Calendar Set Analysis variables be created? Default is true.
+@var Qvc.Calendar.v.Field.Date in Field name for the calendar "Date" field.
+@var Qvc.Calendar.v.Field.Day in Field name for the calendar "Day of Month" field.
+@var Qvc.Calendar.v.Field.Weekday in Field name for the calendar "Weekday" field.
+@var Qvc.Calendar.v.Field.Year in Field name for the calendar "Year" field.
+@var Qvc.Calendar.v.Field.Month in Field name for the calendar "Month" field (1st 3 letters of name, eg "Jan").
+@var Qvc.Calendar.v.Field.MonthName in Field name for the calendar "Month" field (Full name, eg "January").
+@var Qvc.Calendar.v.Field.YearMonth in Field name for the calendar "YearMonth" field.
+@var Qvc.Calendar.v.Field.Quarter in Field name for the calendar "Quarter" field.
+
+@var vSetYTD out Set Analysis expression for Year-To-Date.  Example: Sum( $(vSetYTD) Sales)
+@var vSetQTD out Set Analysis expression for Quarter-To-Date.
+@var vSetMTD out Set Analysis expression for Month-To-Date.
+@var vSetPreviousMonthMTD out Set Analysis expression for Previous-Month-To-Date.
+@var vSetPreviousQuarter out Set Analysis expression for Previous-Quarter-To-Date.
+@var vSetPreviousYearMTD out Set Analysis expression for Previous-Year-Month-To-Date.
+@var vSetPreviousYearQTD out Set Analysis expression for Previous-Year-Quarter-To-Date.
+@var vSetPreviousYearYTD out Set Analysis expression for Previous-Year-Year-To-Date.
+@var vSetRolling12 out Set Analysis expression for Rolling-12-Months. 
+@var vSetYTDModifier out Set modifier arguments for Year-To-Date.  Example: Sum( {<$(vSetYTDModifier), Region={EU}>} Sales)
+@var vSetQTDModifier out Set modifier arguments for Quarter-To-Date.
+@var vSetMTDModifier out Set modifier arguments for Month-To-Date.
+@var vSetPreviousMonthMTDModifier out Set modifier arguments for Previous-Month-To-Date.
+@var vSetPreviousQuarterModifier out Set modifier arguments for Previous-Quarter-To-Date.
+@var vSetPreviousYearMTDModifier out Set modifier arguments for Previous-Year-Month-To-Date.
+@var vSetPreviousYearQTDModifier out Set modifier arguments for Previous-Year-Quarter-To-Date.
+@var vSetPreviousYearYTDModifier out Set modifier arguments for Previous-Year-Year-To-Date.
+@var vSetRolling12Modifier out Set modifier arguments for Rolling-12-Months. 
+*/
+
+
+
+UNQUALIFY "_qvctemp.*";	// UNQUALIFY all qvctemp fields
+
+// Set default _tablename if not supplied
+LET _tableName = if(len('$(_tableName)')=0, 'MasterCalendar','$(_tableName)');
+// Set Default first month if not specified
+LET _firstMonth = if(len('$(_firstMonth)')=0, 1,'$(_firstMonth)');
+LET _monthOffset = -($(_firstMonth)-1);  //Compute month offset for Addmonths function.
+
+REM Make some shorter names for the field variables;
+IF len('$(_Qvc.Calendar.v.Field.Date.Override)') > 0 THEN	// Use the fixed name (from CalendarFromField) if we have one.
+	SET _fDate='[$(_Qvc.Calendar.v.Field.Date.Override)]';
+ELSE 
+	SET _fDate='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.Date)]';
+ENDIF
+SET _fDay='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.Day)]';
+SET _fWeekday='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.Weekday)]';
+SET _fYear='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.Year)]';
+SET _fMonth='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.Month)]';
+// Mark Miller (RHS) 8/9/2016 - Add Month full name to the calendar
+SET _fMonthName='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.Month)Name]';
+SET _fYearMonth='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.YearMonth)]';
+SET _fQuarter='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.Quarter)]';
+SET _f_MonthSerial='[$(_fieldPrefix)_MonthSerial]';
+SET _f_QuarterSerial='[$(_fieldPrefix)_QuarterSerial]';
+SET _f_WeekSerial='[$(_fieldPrefix)_WeekSerial]';
+SET _f_DateSerial='[$(_fieldPrefix)_DateSerial]';
+SET _fYearQuarter='[$(_fieldPrefix)$(Qvc.Calendar.v.Field.YearQuarter)]';
+
+IF len('$(Qvc.Global.Extension.Directory)')> 0 THEN
+	LET _qvctemp.v.IncludeExtension = replace(
+	'@(Include=$(Qvc.Global.Extension.Directory)\$(Qvc.Calendar.v.ExtFields))'
+	,'@','$');
+ELSE 
+	SET _qvctemp.v.IncludeExtension=;	
+ENDIF
+
+LET _concatenate = if($(_Qvc.TableExists($(_tableName))), 'CONCATENATE ([$(_tableName)])', ''); 
+   
+[$(_tableName)]:
+$(_concatenate) 
+LOAD
+	*,
+	dual($(_fYear) & '-' & $(_fMonth),Date(MonthStart($(_fDate),$(_monthOffset))))  as $(_fYearMonth),
+	dual($(_fYear) & '-' & $(_fQuarter),Date(QuarterStart($(_fDate),$(_monthOffset))))  as $(_fYearQuarter)
+;
+
+LOAD
+    Date							as $(_fDate),
+    Day(Date)						as $(_fDay),
+    Weekday(Date)					as $(_fWeekday),
+    Year(AddMonths(Date,$(_monthOffset))) 	as $(_fYear),
+// Mark Miller (RHS) 2/15/2016 - Express the month as a Dual so the months can be sorted by number so the starting month of the year
+// can be always first in list boxes (especially useful for fiscal calendars)
+	Dual(Month(Date), Num(Month(AddMonths(Date,$(_monthOffset))))) AS $(_fMonth),
+//    Month(Date)						as $(_fMonth),
+// Mark Miller (RHS) 8/9/2016 - Add Month full name to the calendar as a Dual
+	Dual(Date([Date],'MMMM'), Num(Month(AddMonths(Date,$(_monthOffset))))) as $(_fMonthName),
+    'Q' & Ceil(Month(AddMonths(Date,$(_monthOffset))) / 3)		as $(_fQuarter),
+    num(Date)					 	as $(_f_DateSerial),
+    AutoNumber(MonthStart(Date),'$(_f_MonthSerial)') 	as $(_f_MonthSerial),
+    AutoNumber(QuarterStart(Date),'$(_f_QuarterSerial)')	as $(_f_QuarterSerial),
+    AutoNumber(weekyear(Date) &'|' & week(Date),'$(_f_WeekSerial)')	as $(_f_WeekSerial)
+   $(_qvctemp.v.IncludeExtension);
+
+;    
+LOAD DISTINCT Date($(_fieldname)) as Date, Count(1) as dummy
+Resident $(_fieldTableName)
+Group by Date($(_fieldname))
+;
+
+SET _concatenate=;
+SET _qvctemp.v.IncludeExtension=;
+IF $(Qvc.Calendar.v.CreateSetVariables) THEN	// If SA variables requested,
+	// Mark Miller (RHS) 8/10/2016 - Break SetVariable generation out to separate routine.
+	CALL Qvc.GenerateCalendarSetVariables;
+ENDIF
+
+
+// Cleanup temp variables
+SET _fDate=;
+SET _fDay=;
+SET _fWeekday=;
+SET _fYear=;
+SET _fMonth=;
+// Mark Miller (RHS) 8/9/2016 - Add Month full name to the calendar
+SET _fMonthName=;
+SET _fYearMonth=;
+SET _fQuarter=;
+SET _f_MonthSerial=;
+SET _f_QuarterSerial=;
+SET _f_WeekSerial=;
+SET _f_DateSerial=;
+SET _monthOffset =;
+SET _fYearQuarter =;
+
+END SUB	
+// End of Qvc.CalendarNoFill Sub
+
+
+// Mark Miller (RHS) 8/10/2016 - Break SetVariable generation out to separate routine.
+SUB Qvc.GenerateCalendarSetVariables
 
 // Mapping table that will be used to translate escaped special chars
 [_qvctemp.Calendar.EscapeCharsMap]:
@@ -336,8 +572,53 @@ MapSubString('_qvctemp.Calendar.EscapeCharsMap',
 >}'
 );
 
+// Mark Miller (RHS) 2/15/2016 - Previous Full Month
+Let $(_fieldPrefix)vSetPreviousFULLMonthModifier = 
+MapSubString('_qvctemp.Calendar.EscapeCharsMap',
+'$(_vClearFieldList)
+$(_f_MonthSerial) = {@(=$(_qvctemp.vMaxModifier) $(_f_MonthSerial)) - 1)}'
+);
 
+Let $(_fieldPrefix)vSetPreviousFULLMonth =
+MapSubString('_qvctemp.Calendar.EscapeCharsMap',
+'{$<
+@($(_fieldPrefix)vSetPreviousFULLMonthModifier)
+>}'
+);
 
+// Mark Miller (RHS) 2/15/2016 - Previous N Full Months
+// Example usage:
+// Count($(Annual_vSetPreviousFULLMonthN(3)) orderNo)	// Count # orders in entire month 3 months prior
+Let $(_fieldPrefix)vSetPreviousFULLMonthNModifier = 
+MapSubString('_qvctemp.Calendar.EscapeCharsMap',
+'$(_vClearFieldList)
+$(_f_MonthSerial) = {@(=$(_qvctemp.vMaxModifier) $(_f_MonthSerial)) - $1)}'
+);
+
+Let $(_fieldPrefix)vSetPreviousFULLMonthN =
+MapSubString('_qvctemp.Calendar.EscapeCharsMap',
+'{$<
+@($(_fieldPrefix)vSetPreviousFULLMonthNModifier($1))
+>}'
+);
+
+// Mark Miller (RHS) 2/15/2016 - Previous N Full Months
+// Example usage:
+// Count($(Annual_vSetRollingN(3)) orderNo)	// Count # orders for prior 3 months
+Let $(_fieldPrefix)vSetRollingNModifier =
+MapSubString('_qvctemp.Calendar.EscapeCharsMap',
+'$(_vClearFieldList)
+$(_f_MonthSerial) = {">=@(=$(_qvctemp.vMaxModifier) $(_f_MonthSerial)) - ($1 - 1))<=@(=$(_qvctemp.vMaxModifier) $(_f_MonthSerial)))"}'
+);
+
+Let $(_fieldPrefix)vSetRollingN =
+MapSubString('_qvctemp.Calendar.EscapeCharsMap',
+'{$<
+@($(_fieldPrefix)vSetRollingNModifier($1))
+>}'
+);
+
+// Rolling 12 Months
 Let $(_fieldPrefix)vSetRolling12Modifier =
 MapSubString('_qvctemp.Calendar.EscapeCharsMap',
 '$(_vClearFieldList)
@@ -357,57 +638,42 @@ MapSubString('_qvctemp.Calendar.EscapeCharsMap',
 SET _vClearFieldList=;
 SET _qvctemp.vMaxModifier=;
 
-ENDIF
+END SUB
+// End of Qvc.GenerateCalendarSetVariables Sub
 
-
-///$tab Cleanup
-// Cleanup temp variables
-SET _fDate=;
-SET _fDay=;
-SET _fWeekday=;
-SET _fYear=;
-SET _fMonth=;
-SET _fYearMonth=;
-SET _fQuarter=;
-SET _f_MonthSerial=;
-SET _f_QuarterSerial=;
-SET _f_WeekSerial=;
-SET _f_DateSerial=;
-SET _monthOffset =;
-			
-END SUB	
-// End of Qvc.Calendar Sub
-
-///$tab CalendarFromField
-SUB Qvc.CalendarFromField(_fieldname, _tableName, _fieldPrefix, _firstMonth)
+// Mark Miller (RHS) 8/8/2016 - Create calendar from field and table without filling in missing dates.
+SUB Qvc.CalendarFromFieldNoFill(_fieldname, _fieldTableName, _tableName, _fieldPrefix, _firstMonth)
 /**
 @source Qvc_Calendar.qvs
-Create a Master Calendar based on the Min and Max values of an existing field. The fieldname is used as the "Date" field in the calendar, providinging automatic lkinkage.
+Create a Master Calendar based on the existing values of an existing field. The fieldname is used as the "Date" field in the calendar, providinging automatic linkage.
 
-This Sub calls Qvc.Calendar to generate the calendar. See the doc for Qvc.Calendar to understand the output and available configuration variables. 
+NOTE! This sub differs from Qvc.CalendarFromField in that missing dates in the field are not "filled in" by the calendar routine - only dates that actually exist in the data are generated.
 
-@syntax CALL Qvc.CalendarFromField ('Fieldname', ['CalendarTableName'], ['FieldPrefix'], [FirstMonth]); 
+This Sub calls Qvc.CalendarNoFill to generate the calendar. See the doc for Qvc.CalendarNoFill to understand the output and available configuration variables. 
+
+@syntax CALL Qvc.CalendarFromFieldNoFill ('Fieldname', 'TableName', ['CalendarTableName'], ['FieldPrefix'], [FirstMonth]); 
  
-@param 1 String. Fieldname that will be used to establish Min and Max values for the Calendar Date.
-@param 2 String. Optional - the name of the Calendar table. If not supplied the default is "MasterCalendar"
-@param 3 String. Optional - A prefix that will be prepended to all field names and Set variables created for this calendar. For the set vars, blanks in this string will be replaced with underscores.
-@param 4 Number. Optional - First month of the year. If you want to work with a fiscal year starting in April, specify 4. 
+@param 1 String. Fieldname that will be used to establish valid values for the Calendar Date.
+@param 2 String. TableName that Fieldname exists in - must be resident table.
+@param 3 String. Optional - the name of the Calendar table. If not supplied the default is "MasterCalendar"
+@param 4 String. Optional - A prefix that will be prepended to all field names and Set variables created for this calendar. For the set vars, blanks in this string will be replaced with underscores.
+@param 5 Number. Optional - First month of the year. If you want to work with a fiscal year starting in April, specify 4. 
 
 */
 UNQUALIFY "_qvctemp.*";	// UNQUALIFY all qvctemp fields
 
-CALL Qvc.GetFieldValues('_vStats', '$(_fieldname)');
+//CALL Qvc.GetFieldValues('_vStats', '$(_fieldname)');
 
 //SET _SaveCalendarDateField='$(Qvc.Calendar.v.Field.Date)';	// Save off the current Date fieldname.
 //SET Qvc.Calendar.v.Field.Date='$(_fieldname)';		// Use the parameter fieldname for the Date field.
 SET _Qvc.Calendar.v.Field.Date.Override='$(_fieldname)';		// Use the parameter fieldname for the Date field.
 // Call Qvc.Calendar to do the work.
-CALL Qvc.Calendar(_vStats.Min, _vStats.Max, '$(_tableName)', '$(_fieldPrefix)', '$(_firstMonth)');
+CALL Qvc.CalendarNoFill(_fieldname, _fieldTableName, '$(_tableName)', '$(_fieldPrefix)', '$(_firstMonth)');
 //SET Qvc.Calendar.v.Field.Date='$(_SaveCalendarDateField)';		// Restore the saved value
 
 SET _Qvc.Calendar.v.Field.Date.Override=;	// Reset to default behavior
 //SET _SaveCalendarDateField=;
-SET _vStats.Min=;
-SET _vStats.Max=;
+// SET _vStats.Min=;
+// SET _vStats.Max=;
 END SUB	
-// End of Qvc.CalendarFromField Sub
+// End of Qvc.CalendarFromFieldNoFill Sub


### PR DESCRIPTION
Added new set variables for RollingN months, Previous FULL MonthN (parameterized) gives the full month x number of months back. Previous FULL Month, gives entire last month, not just last month-to-date.

Added new "MonthName" field to calendar which contains the full name of the month, eg "January" vs. "Jan". This is a Dual() as well.
Changed existing "Month" field to a Dual() so months will always sort correctly for Annual and Fiscal calendars.

Moved all Calendar Set Variable generation to separate routine.
Created two new calendar generation routines:
Qvc.CalendarNoFill(...)
Qvc.CalendarFromFieldNoFill(...)

These new routines create calendars directly from a field (resident table only) and work the same as the existing routines, except only dates that exist in the data is included in the generated calendar. Missing dates in the data are not filled in by these routines.